### PR TITLE
Simplify Audit Exceptions Mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:latest
 
-VOLUME [ "/verify/exceptions" ]
-
 RUN apk --no-cache add openssh-keygen jq openssh-client
 
 COPY --from=hashicorp/terraform:0.14.4 /bin/terraform /bin/terraform

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,12 +8,15 @@ set -eu${DEBUG+x}o pipefail
 #
 function print_usage {
     echo "Usage:"
-    echo "  <cloud> <image_identifier>"
+    echo "  <cloud> <image_identifier> <ignored_controls>"
     echo ""
     echo "Where:"
     echo "  <cloud>             The canonical name of the cloud provider where the"
     echo "                      candidate image exists."
     echo "  <image_identifier>  The unique identifier for the candidate image to test."
+    echo "  <ignored_controls>  Optional. A comma-separated list of control numbers to"
+    echo "                      ignore if they fail."
+    echo "                      e.g. 1.1,2.3.4,3.1.1"
     echo ""
     echo "Environment Variables:"
     echo "  CLOUD_LOCATION      The cloud provider location (zone or region) where the"
@@ -78,6 +81,9 @@ fi
 
 export TF_VAR_image_cloud=$cloud
 export TF_VAR_image_identifier=${2:?"Error: an image identifier must be provided."}
+
+ignored_controls=${3:-}
+
 export TF_VAR_instance_location=${CLOUD_LOCATION:?"Error: an appropriate cloud provider location must be provided via the CLOUD_LOCATION environment variable."}
 export TF_VAR_vpc_identifier=${VPC_IDENTIFIER-""}
 
@@ -92,41 +98,31 @@ terraform init -input=false -upgrade
 exit_code=0
 (
     # Run Terraform to launch the test Instance.
-    terraform apply -input=false -auto-approve || exit_code=2
+    terraform apply -input=false -auto-approve || exit 1
 
-    if [ $exit_code -eq 0 ]; then
-        # Generate the verify.env file which defines environment variables used by
-        # the audit.sh script to ignore justified failures.
-        if [ -f /verify/exceptions/exceptions.json ]; then
-            jq -r 'keys[]' /verify/exceptions/exceptions.json 2> /dev/null > /tmp/verify.env
-        fi
+    if [ $ignored_controls ]; then
+        echo "$ignored_controls" | sed 's/,/\n/g' > /tmp/exceptions
+    fi
+        
+    ip_address=$(terraform output -no-color -json instance_ip | jq -r '.') || exit 1
+    ssh_username=$(terraform output -no-color -json ssh_username | jq -r '.') || exit 1
 
-        ip_address=$(terraform output -no-color -json instance_ip | jq -r '.') || exit_code=4
-        if [ $exit_code -eq 0 ]; then
-            ssh_username=$(terraform output -no-color -json ssh_username | jq -r '.') || exit_code=8
+    # Blocks execution until the SSH port is ready on the specified IP address.
+    ssh_ready $ip_address ${SSH_PORT:-"22"} || exit 1
 
-            if [ $exit_code -eq 0 ]; then
-                # Wait for instance to be provisioned and SSH to become available
-                if ssh_ready $ip_address ${SSH_PORT:-"22"} ; then
-                    # Upload audit.sh and /tmp/verify.env
-                    scp -q -i /tmp/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no /verify/audit.sh "$ssh_username@$ip_address:/tmp/audit.sh"
+    # Upload audit.sh and /tmp/verify.env
+    scp -q -i /tmp/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no /verify/audit.sh "$ssh_username@$ip_address:/tmp/audit.sh"
 
-                    if [ -f /tmp/verify.env ]; then
-                        scp -q -i /tmp/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no /tmp/verify.env "$ssh_username@$ip_address:/tmp/exceptions"
-                    fi
-
-                    # Adjust permissions and ownership of the audit.sh file and run it.
-                    ssh -i /tmp/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR "$ssh_username@$ip_address" "sudo chmod 0755 /tmp/audit.sh"
-                    ssh -i /tmp/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR "$ssh_username@$ip_address" "sudo chown root:root /tmp/audit.sh"
-
-                    # Run the audit.sh script
-                    ssh -i /tmp/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR "$ssh_username@$ip_address" "sudo bash /tmp/audit.sh" || exit_code=16
-                fi
-            fi
-        fi
+    if [ -f /tmp/exceptions ]; then
+        scp -q -i /tmp/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no /tmp/exceptions "$ssh_username@$ip_address:/tmp/exceptions"
     fi
 
-    exit $exit_code
+    # Adjust permissions and ownership of the audit.sh file and run it.
+    ssh -i /tmp/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR "$ssh_username@$ip_address" "sudo chmod 0755 /tmp/audit.sh"
+    ssh -i /tmp/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR "$ssh_username@$ip_address" "sudo chown root:root /tmp/audit.sh"
+
+    # Run the audit.sh script
+    ssh -i /tmp/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR "$ssh_username@$ip_address" "sudo bash /tmp/audit.sh" || exit 1
 ) || exit_code=1
 
 terraform destroy -auto-approve || true

--- a/terraform/gcp/README.md
+++ b/terraform/gcp/README.md
@@ -22,7 +22,7 @@ The Google Cloud Platform also requires a project identifier to be set.  This is
 
 ### Volume Mounts
 
-In addition to the exceptions file, a volume mount is needed to provide access to the Google Cloud Platform credentials stored on the host system, when using Google Cloud Platform.
+When using Google Cloud Platform, a volume mount is needed to provide access to the Google Cloud Platform credentials stored on the host system.
 
 Those credentials should be generated ahead of time using the following command:
 ```

--- a/verify/audit.sh
+++ b/verify/audit.sh
@@ -11,7 +11,7 @@ fi
 function report {
     local control_number=$1
 
-    if [ $exceptions_file_present -ne 0 ] && [ grep -q "^$control_number$" /tmp/exceptions ]; then
+    if [ $exceptions_file_present -ne 0 ] && grep -q "^$control_number$" /tmp/exceptions ; then
         echo "$control_number SKIPPED"
     else
         echo "$control_number FAILED"

--- a/verify/audit.sh
+++ b/verify/audit.sh
@@ -2,21 +2,22 @@
 set -e
 
 failures=0
+exceptions_file_present=0
+
+if [ -f /tmp/exceptions ]; then
+    exceptions_file_present=1
+fi
 
 function report {
-    skip_var=SKIP_$(echo $1 | tr '.' '_')
-    if echo ${!SKIP_*} | grep -q $skip_var; then
-        echo "$1 SKIPPED"
+    local control_number=$1
+
+    if [ $exceptions_file_present -ne 0 ] && [ grep -q "^$control_number$" /tmp/exceptions ]; then
+        echo "$control_number SKIPPED"
     else
-        echo "$1 FAILED"
+        echo "$control_number FAILED"
         failures=$(expr $failures + 1)
     fi
 }
-
-if [ -f /tmp/verify.env ]; then
-    . /tmp/verify.env
-fi
-
 
 # CIS 1.1.1.1
 (


### PR DESCRIPTION
This Pull Request addresses Issue #3 by refactoring the entrypoint.sh script to read the third command line argument as a comma-separated list of control numbers to ignore.

The entrypoint.sh script no longer looks for an exceptions file in the /verify/exceptions volume mount point.  This removes the necessity for the entrypoint.sh script to parse a JSON file, instead the control numbers are given directly to the entrypoint.sh script as a command line argument.

Furthermore, this PR changes how the audit script handles the exceptions.  Previously, the entrypoint.sh script was responsible for generating a file that could be sourced by the audit script, such that a set of environment variables in the form of SKIP_*control_number* would get set.  Upon recording a failed control, the audit script would determine if a corresponding environment variable was set.  This was a cumbersome process, and has been streamlined considerably.

Now, the entrypoint.sh script will translate the comma-separated list of control numbers into a file containing those control numbers, each on their own line.  The file is uploaded to the launched instance just like before, and now the audit script simply greps for the failed control number in that file to determine if it should be marked as **FAILED** or **SKIPPED**.